### PR TITLE
refactor: Add end order checks

### DIFF
--- a/contracts/src/interfaces/ITronRelay.sol
+++ b/contracts/src/interfaces/ITronRelay.sol
@@ -4,4 +4,6 @@ pragma solidity ^0.8.20;
 interface ITronRelay {
     function latestBlock() external returns (uint256);
     function blocks(uint256) external returns (bytes32);
+    function blockTimestamps(bytes32) external returns (uint256);
+    function timestamps() external returns (uint256[]);
 }


### PR DESCRIPTION
We implement a refactor to fix the `endOrder` vulnerability which allowed a prover to create a proof that would not consist of all orders but only of some of the orders and still verify correctly.

We start storing all order and block timestamps so that when the prover sends the `endOrder` chain hash we can recover its timestamp and verify that it is the last possible timestamp of the `endBlock` that is also sent. With this extra verification we are sure that the `endOrder` must be the last chain hash generated before the `endBlock` and therefore if that order is included in the chain hash, all other orders must be.