### PR TITLE
fix: Fixes audit zktron

### DIFF
--- a/contracts/src/TronRelay.sol
+++ b/contracts/src/TronRelay.sol
@@ -21,7 +21,11 @@ contract TronRelay is ITronRelay, Ownable {
         bytes32 blockprint;
     }
 
-    constructor() Ownable(msg.sender) {}
+    constructor(bytes32 blockId, uint256 blockNumber) Ownable(msg.sender) {
+        latestBlockNumber = blockNumber;
+        blocks[blockNumber] = blockId;
+        // this is all blocks we need to correctly operate the system later
+    }
 
     // We do a little optimization trick here.
     // Instead of parsing protobuf which would be pretty expensive
@@ -51,7 +55,7 @@ contract TronRelay is ITronRelay, Ownable {
         bytes[] calldata signatures,
         uint256[] calldata offsets
     ) external {
-        // TODO: We here assume that this function is never used in the first iteration, 
+        // TODO: We here assume that this function is never used in the first iteration,
         //       that is that latestBlockNumber is never 0.
         require(reorgDepth == 0 || newBlocks.length >= 19);
         require(reorgDepth < 19);

--- a/contracts/src/interfaces/ITronRelay.sol
+++ b/contracts/src/interfaces/ITronRelay.sol
@@ -2,6 +2,6 @@
 pragma solidity ^0.8.20;
 
 interface ITronRelay {
-    function latestBlock() external returns (uint256);
+    function latestBlockNumber() external returns (uint256);
     function blocks(uint256) external returns (bytes32);
 }


### PR DESCRIPTION
Fixes:
- Use `latestBlockNumber` over `latestBlock`. Generally when using `block` we mean the `blockId`, so this was confusing
- Add comment for `blocks` mapping
- Add comment to explain that manual update cannot be used with initial conditions
- Add commented code to implement cycle check on manual update which is not implemented
- Fix `output.startBlock` check. We must check that the input to the circuit `startBlock` is actually the stored block id in the SC: `blocks[latestBlockNumber]` rather than `blockIds[latestBlockNumber]` so that we can verify that the circuit is applied from that block id onwards.
- Allow initial conditions on `zkUpdate` function. Since `latestBlockNumber` is initialized to 0 by default then there would be a mismatch between tron block numbers and `latestBlockNumbers`