### PR TITLE
fix: Update order chain to free receiver

### DIFF
--- a/contracts/src/UntronCore.sol
+++ b/contracts/src/UntronCore.sol
@@ -313,6 +313,9 @@ contract UntronCore is Initializable, UntronTransfers, UntronFees, UntronZK, IUn
             // perform the transfer
             smartTransfer(order.transfer, amount);
 
+            // update order chain to free the receiver
+            updateOrderChain(_receivers[i], 0);
+
             // update the order details
 
             // to prevent from modifying the order after it's fulfilled


### PR DESCRIPTION
- Update order chain so that fulfilled order is added to circuit and receiver is freed correctly. 
Orders are created and then are freed if they are stopped, fulfilled or expired (without being stopped or fulfilled previously)